### PR TITLE
Add fsevents to save batteries

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "react-redux": "^4.4.5",
     "react-router": "4.0.0-alpha.5",
     "redux": "^3.6.0"
+  },
+  "optionalDependencies": {
+    "fsevents": "^1.0.15"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2736,6 +2736,13 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
 
+fsevents:
+  version "1.0.15"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.0.15.tgz#fa63f590f3c2ad91275e4972a6cea545fb0aae44"
+  dependencies:
+    nan "^2.3.0"
+    node-pre-gyp "^0.6.29"
+
 fsevents@^1.0.0:
   version "1.0.14"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.0.14.tgz#558e8cc38643d8ef40fe45158486d0d25758eee4"


### PR DESCRIPTION
Prevents Webpack from getting up to 100% CPU usage.