### PR TITLE
Add absolute pathing

### DIFF
--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -9,11 +9,11 @@ export default ({
   <nav role='main'>
     <ul>
       <li>
-        <Link to='explore'>Explore</Link>
+        <Link to='/explore'>Explore</Link>
       </li>
 
       <li className='record'>
-        <Link to='record'>Record</Link>
+        <Link to='/record'>Record</Link>
       </li>
 
       {showUserOrSignUp(isSignedIn)}
@@ -27,7 +27,7 @@ function showUserOrSignUp (isSignedIn) {
   } else {
     return (
       <li>
-        <Link to='signup'>Sign up</Link>
+        <Link to='/signup'>Sign up</Link>
       </li>
     )
   }


### PR DESCRIPTION
In the navigation if you are leaving a user's profile and try to go to explore though the nav, it would link you to `localhost:500/profile/explore` and such for the other links.

As part of the documentation, `react-router` says the `to` prop should represent the absolute path but I don't think that was working as intended, so I think being explicit helps. Feel free to shoot it down. 