### PR TITLE
Fix socket stream disconnection failure

### DIFF
--- a/src/components/draw/AudioRecordingStream.js
+++ b/src/components/draw/AudioRecordingStream.js
@@ -29,7 +29,7 @@ export default class AudioRecordingStream extends React.Component {
   }
 
   componentWillUnmount () {
-    this.stream.end()
+    this.stream && this.stream.end()
     this.client.close()
     this.audioStream.getTracks()[0].stop()
   }

--- a/src/components/streams/PublishStreamContainer.js
+++ b/src/components/streams/PublishStreamContainer.js
@@ -31,7 +31,6 @@ function mapStateToProps (state, ownProps) {
     stream,
     topics,
     initialValues: {
-      ...stream,
       topicId: (topics[0] || {}).id
     }
   }


### PR DESCRIPTION
This fixes an error thrown by clicking "record" and then leaving the record screen immediately.