### PR TITLE
Fix bundle splitting problem for comments

### DIFF
--- a/src/components/comments/Comment.js
+++ b/src/components/comments/Comment.js
@@ -1,7 +1,6 @@
 import React from 'react'
 
-import Bundle from '../Bundle'
-import loadMoment from 'bundle-loader!moment'
+import moment from 'moment'
 
 import { Link } from 'react-router-dom'
 
@@ -13,7 +12,7 @@ export default class Comment extends React.Component {
   }
 
   componentDidMount () {
-    this.interval = setInterval(this.tick, 10000)
+    this.interval = setInterval(() => this.tick(), 10000)
   }
 
   componentWillUnmount () {
@@ -39,9 +38,7 @@ export default class Comment extends React.Component {
 
         <div>
           <p className='ago' title={comment.insertedAt}>
-            <Bundle load={loadMoment}>
-              {(moment) => moment(comment.insertedAt).fromNow(true)}
-            </Bundle>
+            {moment(comment.insertedAt).fromNow(true)}
           </p>
         </div>
       </div>

--- a/src/components/comments/StreamComments.js
+++ b/src/components/comments/StreamComments.js
@@ -2,7 +2,9 @@ import React from 'react'
 import ReactCSSTransitionGroup from 'react-addons-css-transition-group'
 
 import NewCommentContainer from './NewCommentContainer'
-import CommentContainer from './CommentContainer'
+
+import Bundle from '../Bundle'
+import loadCommentContainer from 'bundle-loader!./CommentContainer'
 
 export default ({
   streamId,
@@ -12,17 +14,20 @@ export default ({
   <div className='stream-comments'>
     { (isLoggedIn) ? <NewCommentContainer streamId={streamId} /> : null }
 
-    {comments.length > 0 &&
-      <ReactCSSTransitionGroup
-        transitionName='comment'
-        transitionEnterTimeout={200}
-        transitionLeaveTimeout={200}
-      >
-        {comments.map((comment) => (
-          <CommentContainer key={comment.id} commentId={comment.id} />
-        ))}
-      </ReactCSSTransitionGroup>
-    }
+    <Bundle load={loadCommentContainer}>
+      {(CommentContainer) => (
+        CommentContainer && comments.length > 0 &&
+          <ReactCSSTransitionGroup
+            transitionName='comment'
+            transitionEnterTimeout={200}
+            transitionLeaveTimeout={200}
+          >
+            {comments.map((comment) =>
+              <CommentContainer key={comment.id} commentId={comment.id} />)}
+          </ReactCSSTransitionGroup>
+        )
+      }
+    </Bundle>
 
     {comments.length === 0 &&
       <p className='none'>This stream has no comments.</p>}


### PR DESCRIPTION
This was an error I _thought_ was only happening in production, but in fact was actually only present on Streams with comments.

Basically, `bundle-loader` seems to be struggling to correctly load the Moment library. This gets around that by just asynchronously loading the whole CommentContainer component, which actually reduced the bundle size more. Win-win!